### PR TITLE
add fallback

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,6 +4,10 @@ class ApiController < ActionController::API
 
   include Knock::Authenticable
 
+  # def fallback_index_html
+  #   render file: 'public/index.html'
+  # end
+    
   protected
 
   def set_user!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
-    include Knock::Authenticable
+  include Knock::Authenticable
+
+  def fallback_index_html
+    render file: 'public/index.html'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get '*path', to: "application#fallback_index_html", constraints: -> (request) do
+    !request.xhr? && request.format.html?
+  end
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
This PR adds a `fallback_index_html` method to the `ApplicationController` to avoid issues with React router (along with its accompanying use in `routes.rb`) 